### PR TITLE
Fix paths when model is run with mock assignment

### DIFF
--- a/src/background/helmet_entrypoint_python_shell.js
+++ b/src/background/helmet_entrypoint_python_shell.js
@@ -22,6 +22,8 @@ module.exports = {
           "--log-level", allRunParameters[0].log_level,
           "--log-format", "JSON",
           "--baseline-data-path", allRunParameters[0].base_data_folder_path,
+          "--results-path", allRunParameters[0].results_data_folder_path,
+          "--scenario-name", allRunParameters[0].name,
         ]
           .concat(["--emme-paths"]).concat(allRunParameters.map(p => p.emme_project_file_path))
           .concat(["--first-scenario-ids"]).concat(allRunParameters.map(p => p.first_scenario_id))

--- a/src/background/helmet_entrypoint_python_shell.js
+++ b/src/background/helmet_entrypoint_python_shell.js
@@ -21,7 +21,7 @@ module.exports = {
         args: [
           "--log-level", allRunParameters[0].log_level,
           "--log-format", "JSON",
-          "--baseline-data-path", allRunParameters[0].base_data_folder_path
+          "--baseline-data-path", allRunParameters[0].base_data_folder_path,
         ]
           .concat(["--emme-paths"]).concat(allRunParameters.map(p => p.emme_project_file_path))
           .concat(["--first-scenario-ids"]).concat(allRunParameters.map(p => p.first_scenario_id))


### PR DESCRIPTION
Running HELMET without EMME (`dev-config.json` > `"USE_EMME" = false`) failed before. The reason was that results folder paths were not passed to `helmet_validate_inputs.py`. Instead, they were read from `dev-config.json`.

This PR was tested to work with the test scenario in helmet-model-system without using Emme.

Closes #89 