### PR TITLE
Small improvements

### DIFF
--- a/src/renderer/components/HelmetProject/CostBenefitAnalysis/CostBenefitAnalysis.jsx
+++ b/src/renderer/components/HelmetProject/CostBenefitAnalysis/CostBenefitAnalysis.jsx
@@ -12,7 +12,7 @@ const CostBenefitAnalysis = ({
             {/* Baseline scenario results folder */}
             <td>
               <span className="CBA__pseudo-label">Vertailuvaihtoehto</span>
-              <label className="CBA__pseudo-file-select" htmlFor="baseline-scenario-results-folder-select">
+              <label className="CBA__pseudo-file-select" htmlFor="baseline-scenario-results-folder-select" title={cbaOptions.baseline_scenario_path}>
                 {cbaOptions.baseline_scenario_path ? path.basename(cbaOptions.baseline_scenario_path) : "Valitse.."}
               </label>
               <input className="CBA__hidden-input"
@@ -31,7 +31,7 @@ const CostBenefitAnalysis = ({
             {/* Projected scenario results folder */}
             <td>
               <span className="CBA__pseudo-label">Hankevaihtoehto</span>
-              <label className="CBA__pseudo-file-select" htmlFor="projected-scenario-results-folder-select">
+              <label className="CBA__pseudo-file-select" htmlFor="projected-scenario-results-folder-select" title={cbaOptions.projected_scenario_path}>
                 {cbaOptions.projected_scenario_path ? path.basename(cbaOptions.projected_scenario_path) : "Valitse.."}
               </label>
               <input className="CBA__hidden-input"
@@ -52,7 +52,7 @@ const CostBenefitAnalysis = ({
             {/* Baseline scenario 2 results folder */}
             <td>
               <span className="CBA__pseudo-label">Vertailuvaihtoehto vuosi 2 (valinnainen)</span>
-              <label className="CBA__pseudo-file-select" htmlFor="baseline-scenario-2-results-folder-select">
+              <label className="CBA__pseudo-file-select" htmlFor="baseline-scenario-2-results-folder-select" title={cbaOptions.baseline_scenario_2_path}>
                 {cbaOptions.baseline_scenario_2_path ? path.basename(cbaOptions.baseline_scenario_2_path) : "Valitse.."}
               </label>
               <input className="CBA__hidden-input"
@@ -71,7 +71,7 @@ const CostBenefitAnalysis = ({
             {/* Projected scenario 2 results folder */}
             <td>
               <span className="CBA__pseudo-label">Hankevaihtoehto vuosi 2 (valinnainen)</span>
-              <label className="CBA__pseudo-file-select" htmlFor="projected-scenario-2-results-folder-select">
+              <label className="CBA__pseudo-file-select" htmlFor="projected-scenario-2-results-folder-select" title={cbaOptions.projected_scenario_2_path}>
                 {cbaOptions.projected_scenario_2_path ? path.basename(cbaOptions.projected_scenario_2_path) : "Valitse.."}
               </label>
               <input className="CBA__hidden-input"

--- a/src/renderer/components/HelmetProject/HelmetScenario/HelmetScenario.jsx
+++ b/src/renderer/components/HelmetProject/HelmetScenario/HelmetScenario.jsx
@@ -70,7 +70,7 @@ const HelmetScenario = ({scenario, updateScenario, closeScenario, existingOtherN
 
       {/* Folder path to variable input data (input data with variables sent to EMME) */}
       <div className="Scenario__section">
-        <span className="Scenario__pseudo-label">L&auml;ht&ouml;data</span>
+        <span className="Scenario__pseudo-label">Sy&ouml;tt&ouml;tiedot</span>
         <label className="Scenario__pseudo-file-select" htmlFor="data-folder-select">
           {scenario.forecast_data_folder_path ? path.basename(scenario.forecast_data_folder_path) : "Valitse.."}
         </label>

--- a/src/renderer/components/HelmetProject/HelmetScenario/HelmetScenario.jsx
+++ b/src/renderer/components/HelmetProject/HelmetScenario/HelmetScenario.jsx
@@ -39,7 +39,7 @@ const HelmetScenario = ({scenario, updateScenario, closeScenario, existingOtherN
       {/* File path to EMME project reference-file (generally same in all scenarios of a given HELMET project) */}
       <div className="Scenario__section">
         <span className="Scenario__pseudo-label">EMME projekti (.emp)</span>
-        <label className="Scenario__pseudo-file-select" htmlFor="emme-project-file-select">
+        <label className="Scenario__pseudo-file-select" htmlFor="emme-project-file-select" title={scenario.emme_project_file_path}>
           {scenario.emme_project_file_path ? path.basename(scenario.emme_project_file_path) : "Valitse.."}
         </label>
         <input className="Scenario__hidden-input"
@@ -71,7 +71,7 @@ const HelmetScenario = ({scenario, updateScenario, closeScenario, existingOtherN
       {/* Folder path to variable input data (input data with variables sent to EMME) */}
       <div className="Scenario__section">
         <span className="Scenario__pseudo-label">Sy&ouml;tt&ouml;tiedot</span>
-        <label className="Scenario__pseudo-file-select" htmlFor="data-folder-select">
+        <label className="Scenario__pseudo-file-select" htmlFor="data-folder-select" title={scenario.forecast_data_folder_path}>
           {scenario.forecast_data_folder_path ? path.basename(scenario.forecast_data_folder_path) : "Valitse.."}
         </label>
         <input className="Scenario__hidden-input"


### PR DESCRIPTION
Muutettu skenaarion asetuksissa: Lähtötiedot -> Syöttötiedot

Termien selitykset:
- Projektin asetuksissa: Lähtötiedot = Nykytilanteen lähtö- eli syöttötiedot (`2016_zonedata` & `base_matrices`)
- Skenaarion asetuksissa: Syöttötiedot = Ennusteskenaarioiden syöttötiedot (samat tietotyypit kuin `2016_zonedata` pois lukien `.car`)

Also added hovers to file path boxes on scenario settings and CBA settings.

Closes #71