### PR TITLE
Find Python 3 under Emme 4.5.0

### DIFF
--- a/src/renderer/components/Settings/Settings.jsx
+++ b/src/renderer/components/Settings/Settings.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import path from "path";
 const {dialog} = require('@electron/remote');
+import {searchEMMEPython} from './search_emme_pythonpath';
+import versions from '../versions';
 
 const Settings = ({
   emmePythonPath, setEMMEPythonPath,
@@ -32,6 +34,19 @@ const Settings = ({
                  accept=".exe"
                  onChange={(e) => setEMMEPythonPath(e.target.files[0].path)}
           />
+        <button className="Settings__beside-input-btn"
+                  onClick={(e) => {
+                    const [found, pythonPath] = searchEMMEPython();
+                    if (found) {
+                      if (confirm(`Python ${versions.emme_python} löytyi sijainnista:\n\n${pythonPath}\n\nHaluatko käyttää tätä sijaintia?`)) {
+                        setEMMEPythonPath(pythonPath);
+                      }
+                    } else {
+                      alert(`Emme ${versions.emme_system} ja Python ${versions.emme_python} eivät löytyneet oletetusta sijainnista.\n\nSyötä Pythonin polku manuaalisesti.`);
+                    }}}
+          >
+            Hae Python automaattisesti
+          </button>
         </div>
         <div className="Settings__dialog-input-group">
           <span className="Settings__pseudo-label">HELMET model-system</span>

--- a/src/renderer/components/Settings/Settings.jsx
+++ b/src/renderer/components/Settings/Settings.jsx
@@ -24,7 +24,7 @@ const Settings = ({
         </button>
         <div className="Settings__dialog-heading">Projektin asetukset</div>
         <div className="Settings__dialog-input-group">
-          <span className="Settings__pseudo-label">Emme Python (v3.7)</span>
+          <span className="Settings__pseudo-label">Emme Python v3.7</span>
           <label className="Settings__pseudo-file-select" htmlFor="hidden-input-emme-python-path" title={emmePythonPath}>
             {emmePythonPath ? path.basename(emmePythonPath) : "Valitse.."}
           </label>

--- a/src/renderer/components/Settings/Settings.jsx
+++ b/src/renderer/components/Settings/Settings.jsx
@@ -22,7 +22,7 @@ const Settings = ({
         </button>
         <div className="Settings__dialog-heading">Projektin asetukset</div>
         <div className="Settings__dialog-input-group">
-          <span className="Settings__pseudo-label">EMME Python (v2.7)</span>
+          <span className="Settings__pseudo-label">Emme Python (v3.7)</span>
           <label className="Settings__pseudo-file-select" htmlFor="hidden-input-emme-python-path" title={emmePythonPath}>
             {emmePythonPath ? path.basename(emmePythonPath) : "Valitse.."}
           </label>

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,4 @@
 module.exports = {
-    emme_system: '4.4.2',
-    emme_python: '2.7',
+    emme_system: '4.5.0',
+    emme_python: '3.7',
 };


### PR DESCRIPTION
Searches for Python version 3.7 under Emme version 4.5.0. Works exactly the same as the previous UI version, meaning that there are no additional checks of the version compatibility.

I ran `npm run make`, copied the setup exe into Emme computer, and tested. It works!

Fixes #114 