### PR TITLE
Re-arrange docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,68 +10,6 @@ HSL ja muut tahot käyttävät Helmet-mallia myös monissa muissa töissä, kute
 Mallin avulla saadaan tietoa suunnitteluratkaisuihin ja valintoihin jo suunnitteluprosessin aikana, ja sen avulla arvioidaan suunnittelun vaikutuksia ”etukäteen”.
 Malli tuo esiin esimerkiksi linjastouunnitelman tai liikennehankkeen vaikutukset/vaikutuksia kulkumuotojakaumaan,
 matka-aikaan, saavutettavuuteen, matkamääriin ja liikennesuoritteisiin.
-Lisätietoa ja esimerkkejä mallilla tuotettavista tarkasteluista [täällä](esimerkkeja_tuloksista.md).
-
-## Helmet-järjestelmän käyttö
-
-Järjestelmän asennus- ja käyttöohjeet löydät [täältä](kaytto-ohje.md),
-ja tarkempia lähtötietojen käsittelyn ohjeita sekä Helmet-makrojen ohjeet ja latauslinkin [täältä](sijopankki.md).
-Lisätietoa mallijärjestelmän käyttämisestä löydät [täältä](mallitoiden_yleisohje.md).
-Lisätietoa etenkin HSL:n teettämien mallitöiden tilaamisesta löydät [täältä](HSL-mallitoiden_tilaajan_ohje.md).
-
-### Tietopyynnöt
-
-Liikenne-ennusteisiin ja näiden tuloksiin liittyvä tietopyynnöt kannattaa osoittaa Jens Westille ja Mervi Vataselle.
-Pääsääntöisesti tietopyyntöihin pyritään vastaamaan MAL-työn virallisilla ennusteilla, mutta tapauskohtaisesti voidaan toimittaa myös muuta aineistoa. 
-
-HSL:n tarjoamista lähtötiedoista lisätietoa [täällä](HSL_lahtotiedot.md).
-
-## Mallin lähtötiedot
-
-Lähtötietojen määrittäminen on jo itsessään ennustamista. HSL ylläpitää lähtötietoaineistoja MAL-suunnittelun ja joukkoliikennesuunnittelun tueksi.
-Lisätietoja HSL:n tarjoamista aineistoista [täällä](HSL_lahtotiedot.md).
-
-Helmet-mallin lähtötiedoiksi tarvitaan seuraavat tiedot:
-
-**Alueiden maankäyttöä koskevat tiedot:**
-* Asukkaiden kokonaismäärät ja ikäryhmien osuudet
-* Työpaikkojen kokonaismäärät
-* Kaupan työpaikkojen osuus kaikista työpaikoista 
-* Palvelutyöpaikkojen osuus kaikista työpaikoista 
-* Teollisuustyöpaikkojen osuus kaikista työpaikoista 
-* Logistiikan työpaikkojen osuus kaikista työpaikoista 
-* 1., 2. ja 3. asteen oppilaspaikkamäärät
-* Kerros- ja pientalojen osuudet
-
-**Liikennejärjestelmää koskevat tiedot:**
-* Henkilöauton kilometrikustannus (polttoaine, renkaat)
-* Joukkoliikenteen vyöhykehinnat
-* Tie-ja katuverkon ominaisuudet (linkin tieluokka, kaistamäärä, pituus)
-* Joukkoliikennelinjasto (linjatunnus, reitti, keskimääräinen vuoroväli)
-* Työmatkojen pysäköintimaksu alueittain
-* Asiointimatkojen pysäköintimaksut alueittain
-
-### Lähtötietojen vaikutus ennustemallin eri osiin
-
-* Autonomistus alueittain
-  * Kerros- ja pientalojen osuudet
-  * Matka-aikasuhteet
-* Matkamäärä alueittain
-  * Asukasmäärä ikäryhmittäin
-  * Autonomistus
-* Kulkutavan valinta
-  * Alueparien väliset matka-ajat autolla ja joukkoliikenteellä
-  * Alueparien väliset etäisyydet polkupyörällä ja autolla
-  * Alueparien väliset matkakustannukset: joukkoliikennelipun hinta, autoiun muuttuvat kustannukset (polttoaine, renkaat) ja mahdollinen ruuhkamaksu/tietulli
-  * Autonomistus alueittain
-* Matkakohteiden valinta
-  * Saavutettavuus (matka-aika, etäiyys ja matkakustannus määräpaikkaan eri kulkutavoilla)
-  * Työpaikkamäärä määräpaikassa
-  * Oppilaspaikkojen määrä määräpaikassa
-* Reitin valinta
-  * Auto- ja joukkoliikennelinkin matka-aika
-  * Pyörälinkin pituus
-  * Autolinkin matkakustannus 
 
 ## Mallijärjestelmän rakenne
 
@@ -139,38 +77,6 @@ ei kulkutavan valintaan tai suuntautumiseen.
   * Pyöräkaista
   * Sekaliikenne (oletus)
 * Pyöräilyn yhteydet vaikuttavat reitinvalintoihin
-
-### Tulokset verrattuna Helmet 3.1:een
-
-Autoliikenteen liikennemäärät ovat pääväylillä hieman pienempiä kuin Helmet 3.1 versiossa ja vastaavasti poikittaisessa liikenteessä kehäteillä on enemmän kuormitusta.
-Uudet liikennemäärät vastaavat hieman paremmin laskentatietoja, mutta molemmissa malliversiossa vastaavuus on hyvällä tasolla.
-
-Joukkoliikennekulkutapojen väliset painosuhteet muuttuvat siten, että uusi malliversio ennustaa enemmän juna- ja raitiotiematkoja,
-mikä on todennäköisesti seurausta joukkoliikenteen ruuhkasijoittelun käyttöönotosta malliversioiden välillä.
-Muutos on juna- ja raitioliikenteessä oikeansuuntainen suhteessa laskentatietoihin.
-
-Muutoksiin reagoimisen osalta malli toimii vähemmän herkästi suhteessa Helmet 3.1 -malliin.
-Erityisenä huomiona muutoksien osalta aiemman malliversion jalankulkumalli reagoi hyvin voimakkaasti pysäköintimaksujen nostoon,
-koska kustannus oli mallissa mukana suorana matkojen määrää ennustavana muuttujana ja kulkutavan valinta ei ollut liitoksissa muiden kulkutapojen
-valintaan ja olosuhteiden kehitykseen.
-
-### Helmet 4 -tuloksiin liittyviä epävarmuuksia
-
-Mallia laadittaessa sen antamia tuloksia on verrattu monipuolisesti erilaiseen havaintoaineistoon ja pyritty saamaan tulokset vastaamaan mahdollisimman hyvin havaintoja.
-Tuloksiin liittyy silti tiettyjä epävarmuuksia ja rajoitteita, joista on nostettu tähän keskeisimpiä havaintoja.
-Mallin testausta ja testien tuloksia on kuvattu laajemmin raportissa
-[Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://hslfi.azureedge.net/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf) (luvut 12 ja 13).
-
-Nykytilanteen osalta malli toimii hyvin, eikä kysynnän ennustamiseen liittyviä systemaattisia virheitä testauksessa havaittu.
-Malli tuottaa suuntautumisen, autoliikennemäärien ja pyöräliikennemäärien osalta ulkopuolisia havaintoja vastaavia nykytilanteen ennusteita.
-Mallin tulokset eivät poikkea nykytilanteen osalta merkittävästi Helmet 3.1-versiosta.
-
-Joukkoliikenteen osalta havaittiin kuitenkin ongelma, joka on syytä huomioida hanketarkasteluissa.
-Vuorokauden matkustajamääräarviot on aliarvioitu runkoyhteyksillä metrolla, junalla ja raitiovaunuilla, kun taas bussien matkustajamäärät on hieman yliarvioitu.
-Huipputuntien osalta nykyennuste vastaa laskentoja hyvin, joten ongelma on todennäköisesti vuorokausilaajennuskertoimissa,
-jotka eivät nykyisellään huomioi runkoyhteyksien ja muiden yhteyksien erilaisia liikennöintiaikoja.
-
-Helmet 4 -mallin avulla tehtäviä H/K-laskelmia kannattanee hyödyntää vain suurille liikennejärjestelmätason hankkeille.
 
 ## Mallintamisen taustoja
 

--- a/docs/kaytto-ohje.md
+++ b/docs/kaytto-ohje.md
@@ -2,7 +2,7 @@
 sort: 1
 ---
 
-# Ohjeet Helmet 4.1 -liikenne-ennustejärjestelmän käyttöönottoon
+# Helmet 4.1 -liikenne-ennustejärjestelmän käyttöönotto
 
 Tässä ohjeessa kuvataan [Helmet 4.1-liikenne-ennustejärjestelmän](https://github.com/HSLdevcom/helmet-model-system) käyttöliittymää. 
 Järjestelmä käyttää INROn [Emme–ohjelmistoa](https://www.inrosoftware.com/en/products/emme/).

--- a/docs/kaytto-ohje.md
+++ b/docs/kaytto-ohje.md
@@ -2,14 +2,12 @@
 sort: 1
 ---
 
-# Ohjeet Helmet 4.1 -liikenne-ennustejärjestelmän käyttöön
+# Ohjeet Helmet 4.1 -liikenne-ennustejärjestelmän käyttöönottoon
 
 Tässä ohjeessa kuvataan [Helmet 4.1-liikenne-ennustejärjestelmän](https://github.com/HSLdevcom/helmet-model-system) käyttöliittymää. 
 Järjestelmä käyttää INROn [Emme–ohjelmistoa](https://www.inrosoftware.com/en/products/emme/).
 
-## Asennus ja käytön aloitus
-
-### Emmen asennus
+## Emmen asennus
 
 Ennen kuin Helmet UI -käyttöliittymää voidaan käyttää, seuraavien edellytysten on täytyttävä:
 
@@ -24,7 +22,7 @@ Ennen kuin Helmet UI -käyttöliittymää voidaan käyttää, seuraavien edellyt
 3.	[valinnainen] [Helmet 4.1 Model System](https://github.com/HSLdevcom/helmet-model-system) on ladattu käyttöön ja määritelty 
    _(tai annetaan tämän käyttöliittymän ladata se)_
 
-### Emme-projektin määrittely
+## Emme-projektin määrittely
 
 Seuraavaksi sinun on määriteltävä *Emme-projekti*. 
 Kutakin projektia varten kannattaa luoda yksi yhteinen Emme-projektipankki, johon kootaan eri Helmet-skenaariot (esim. eri linjastovaihtoehdot).
@@ -36,7 +34,7 @@ Kutakin projektia varten kannattaa luoda yksi yhteinen Emme-projektipankki, joho
 3. Noudata [erillistä ohjetta](sijopankki.md), jossa kerrotaan mm. sopivista dimensioista (solmujen, linkkien ym. maksimimäärät). 
    Ne vaikuttavat em. `emmebank`-tiedoston kokoon. Aja sisään verkot ja linjastot ohjeen mukaan.
 
-### Helmet-asennus
+## Helmet-asennus
 
 Helmet-käyttöliittymän asennustiedosto ladataan [releases-sivulta](https://github.com/HSLdevcom/helmet-ui/releases).
 Asennustiedosto on nimeltään `Helmet.4.1-x.y.z.Setup.exe`, jossa `x.y.x` on käyttöliittymän
@@ -73,78 +71,3 @@ Nämä kommennot pyörivät hiljaa taustalla, ja sovellus alkaa reagoida vasta n
 Emmen Python-polussa oleva määrittely saattaa epäonnistua, 
 jos ympäristömuuttujaa ’EMMEPATH’ ei ole määritelty tai jos sovellus on asennettu epätavallisella tavalla. Jos näin käy, suorituskelpoisen 
 Python-kielen ja kansion Scripts sijainti on määriteltävä manuaalisesti Asetukset-valikosta.
-
-## Malliajojen ohje
-
-Asennuksen jälkeen pääset määrittämään projektin asetukset ja lähtötiedot.
-
-### Asetukset
-
-Mallin ajoa varten tulee määritellä seuraavat asetukset. 
-
-:warning: **Kansiopoluissa ei saa olla ääkkösiä!**
-
-- Suorituskelpoinen Emme Python 
-  - Tämän **on oltava** Emmen mukana tullut ’python.exe’, jotta tietyt edellytykset täyttyvät.
-  - esim. `C:\Program Files\INRO\Emme\Emme 4\Emme-4.5.0\Python37\python.exe`
-- GitHubin [Helmet 4.1 Model System](https://github.com/HSLdevcom/helmet-model-system)-sivuston kansio ’Scripts’
-  - Kansiossa ovat järjestelmän käyttämät Python-ohjelmat.
-  - Version päivitys voidaan tehdä klikkaamalla "Lataa eri versio...". Nämä eivät korvaa skriptien vanhoja versioita, 
-  vaan uusimmat versiot skripteistä talletetaan uuteen kansioon.
-  - Voidaan käyttää myös olemassa olevaa kansiota.
-- Projektin kansiopolku
-  - Tänne talletetaan Helmet-skenaarioiden (malliajojen) määrittelyt (.json)
-  - Tämä **ei** siis viittaa Emmen projektitiedostoon (.emp)
-- Lähtödatan sisältävä kansio
-  - Tässä ovat omissa alakansioissaan pohjakysyntämatriisit ja nykytilanteen syöttötiedot (2018)
-  - Kansion sisällön saa HSL:ltä (ks. [lähtötietotiedostojen ohje](mallin_lahtotietotiedostot.md))
-- Tulosten tallennuspolku
-  - Tänne talletetaan ennusteajojen tulokset
-
-Näiden asetusten lisäksi on kehittäjille tarkoitettuja asetuksia helmet-model-system -kansion tiedostossa `dev-config.json`.
-Näihin ei ole tavalliselle käyttäjälle yleensä syytä koskea, mutta joissain tapauksissa hyödyllinen asetusmahdollisuus ei ole vielä implementoitu käyttöliittymään.
-Lisää tietoja `dev-config.json`-tiedoston asetuksista löytyy 
-[tästä](https://github.com/HSLdevcom/helmet-model-system/tree/olusanya/Scripts#configuring-the-model-run-with-dev-configjson).
-
-### Malliajon määrittely
-
-Jokaista ajettavaa HELMET-skenaariota kohden on tehtävä seuraavat määrittelyt:
-
-1.	Skenaarion tai ajon nimi
-    - *Skenaario* ei tässä viittaa Emme-skenaarioon, vaan tässä annetaan nimi verkkokuvaus- ja maankäyttötietoyhdistelmälle joka menee yhteen malliajoon.
-2.	Emmen project-tiedosto (.emp)
-3.	Emme-skenaarion numero. 
-   Asetuksista riippuen sijoittelutulokset tallennetaan tähän skenaarioon tai erikseen seuraavaan neljään skenarioon (vrk, aht, pt, iht).
-4.	Kansio, jossa ovat syöttötiedot
-    - esim. `C:\Helmet\Scenario_input_data\2030`
-    - Kansiossa on oltava *yksi* kappale kustakin tiedostotyypista .cco, .edu, .ext, .lnd, .pop, .prk, .tco, .trk sekä .wrk. 
-      Tiedostojen nimillä ei ole merkitystä, ja ne voivat poiketa toisistaan (kansiossa voi esim. olla 2023.pop ja 2023_b.wrk).
-5.	Suoritettavien iteraatiokierrosten enimmäismäärä (yleensä 10)
-    - Voit myös tehdä pelkän loppusijoittelun, jolloin iteraatioita ei ajeta. Pelkän
-      loppusijoittelun tekeminen vaatii, että kysyntämatriisit omx-muodossa aiemmasta malliajosta
-      löytyvät skenaarion tuloskansiosta.
-6.	Valinta, lasketaanko joukkoliikenteen kustannusmatriisi vai käytetäänkö aiemmin laskettua 
-   (sijaitsee tämän skenaarion tuloskansiossa `Tulosten tallennuspolku\Skenaario nimi`).
-7.  Valinta, poistetaanko sijoittelun strategiatiedostot malliajon jälkeen.
-8.  Valinta, tallennetaanko eri ajanjaksot erillisiin Emme-skenaarioihin.
-9.  Valinta, tallennetaanko mm. joukkoliikenteen matka-ajan osamatriisit (in-vehicle time, first
-    waiting time, jne.). Malliajoon ja hankearviointiin tarpeelliset matriisit tallennetaan
-    aina .omx-muodossa riippumatta tästä valinnasta.
-    - Mikäli halutaan useiden Helmet-skenaarioiden kaikki Emme-matriisit talteen samaan
-      Emme-projektiin (.emx-tiedostoihin), voidaan lisäksi ennen jokaista malliajoa määrittää
-      ensimmäisen matriisin numero. Varataan yhteen malliajoon aina 300 matriisin numeroavaruus,
-      joten jos ensimmäiseen malliajoon on käytetty 100 (oletus), toiseen malliajoon kannattaa
-      laittaa 400.
-
-### Hyöty-kustannusanalyysin (hankearvioinnin) määrittely
-
-H/K-analyysillä voidaan verrata ajettujen skenaarioiden hyötyjä ja kustannuksia. Tulokset tulostuvat excel-tiedostoon tuloskansiossa. Analyysia varten on määriteltävä:
-
-1. Vertailuvaihtoehdon (ve0) tuloskansio (`Tulosten tallennuspolku\Skenaarion nimi`)
-2. Hankevaihtoehdon (ve1) tuloskansio
-
-Jos ennusteita on ajettu kahdelle vuodelle (esim. 2040 ja 2060), vertailuvaihtoehto ja hankevaihtoehto on mahdollista määrittää toisellekin ennustevuodelle.
-
-### Tulosten käsittely ja tulkinta
-
-Lisätietoa mallin tuottamista tulostiedostoista ja tulosten tulkinnasta [täällä](tulokset.md).

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -71,3 +71,25 @@ Jos teet merkittäviä muutoksia, esim. lisäät uuden kulkumuodon, sovi tästä
 
 Lisätietoja mallin käyttämisestä [täällä](mallitoiden_yleisohje.md).
 Taustatietoa verkkokuvausten muodostamisesta ja historiasta löydät raportista [Helsingin seudun työssäkäyntialueen  liikenne-ennustejärjestelmän tarjontamallit 2017](https://hslfi.azureedge.net/globalassets/julkaisuarkisto/2019/helsingin-seudun-tyossakayntialueen-liikenne-ennustejarjestelman-tarjontamallit-6-2019.pdf).
+
+## Lähtötietojen vaikutus ennustemallin eri osiin
+
+* Autonomistus alueittain
+  * Kerros- ja pientalojen osuudet
+  * Matka-aikasuhteet
+* Matkamäärä alueittain
+  * Asukasmäärä ikäryhmittäin
+  * Autonomistus
+* Kulkutavan valinta
+  * Alueparien väliset matka-ajat autolla ja joukkoliikenteellä
+  * Alueparien väliset etäisyydet polkupyörällä ja autolla
+  * Alueparien väliset matkakustannukset: joukkoliikennelipun hinta, autoiun muuttuvat kustannukset (polttoaine, renkaat) ja mahdollinen ruuhkamaksu/tietulli
+  * Autonomistus alueittain
+* Matkakohteiden valinta
+  * Saavutettavuus (matka-aika, etäiyys ja matkakustannus määräpaikkaan eri kulkutavoilla)
+  * Työpaikkamäärä määräpaikassa
+  * Oppilaspaikkojen määrä määräpaikassa
+* Reitin valinta
+  * Auto- ja joukkoliikennelinkin matka-aika
+  * Pyörälinkin pituus
+  * Autolinkin matkakustannus

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -1,5 +1,5 @@
 ---
-sort: 5
+sort: 4
 ---
 
 # Mallin lähtötietotiedostot ja niiden muokkaaminen

--- a/docs/mallitoiden_yleisohje.md
+++ b/docs/mallitoiden_yleisohje.md
@@ -1,53 +1,102 @@
 ---
-sort: 2
+sort: 3
 ---
 
 # Ohje mallitöihin
 
-Perehdythän tähän ohjeeseen ennen Helmet-mallin käyttöä! 
+On tärkeää, että mallia käytetään ja muokataan yhtenäisillä periaatteilla. 
+Näin saadaan mahdollisimman luotettavia tuloksia, ja mahdollistetaan aineistojen  hyödyntäminen myös muissa projekteissa. 
+Myös työn huolellinen dokumentointi on tärkeää, sillä se auttaa aineistojen tulkinnassa ja myöhemmässä hyödyntämisessä. 
 
-On tärkeää, että mallia käytetään ja muokataan yhtenäisillä periaatteilla. Näin saadaan mahdollisimman luotettavia tuloksia, ja mahdollistetaan aineistojen  hyödyntäminen myös muissa projekteissa. Myös työn huolellinen dokumentointi on tärkeää, sillä se auttaa aineistojen tulkinnassa ja myöhemmässä hyödyntämisessä. 
+Mallin käyttämiä lähtötietoja on kuvattu [täällä](mallin_lahtotietotiedostot.md). 
+HSL:n lähtötietoaineistot (mm. maankäytöt ja verkkojen tiedot) saat ladattua zip-pakettina, kun olet täyttänyt aineistojen luovutuksen hakemuslomakkeen.
+Näistä löydät yleistietoa [täältä](HSL_lahtotiedot.md).
+Hakemuslomake löytyy Teams-ryhmästä EXT-Helmet, jonne saat käyttöoikeuden HSL:n Liikennejärjestelmäryhmästä (Jens West).
+Kutakin projektia varten tulee hakea uudet aineistot, jotta aineistojen käyttöä voidaan seurata sekä varmistutaan, että lähtötiedot ovat aina ajan tasalla.
 
-Noudatathan näitä käyttö- ja dokumentointiohjeita HSL:n tilaamissa töissä. Ohjeita suositellaan lisäksi noudattamaan myös muissa Helmet-tarkasteluissa. HSL:n yhteyshenkilöiltä saat tarvittaessa apua pulmatilanteisiin. Ilmoitathan HSL:n yhteyshenkilöille myös mikäli havaitset virheitä tai puutteita mallissa.
+Mallin asennusohjeet löydät [täältä](kaytto-ohje.md), ja Emme-pankin perustamisen ohjeet [täältä](sijopankki.md).
+Kutakin projektia varten kannattaa luoda yksi yhteinen Emme-pankki, johon kootaan eri Helmet-skenaariot (esim. eri linjastovaihtoehdot).
+Pääosin suositellaan käytettäväksi vain HSL:n julkaisemia skriptejä ja näiden oletusparametrejä.
+Poikkeamat näihin on syytä dokumentoida huolella (ks. [dokumentointiohje](HSL-toiden_dokumentointi.md)).
 
-## Yleiskuvaus
+## Malliajojen ohje
 
-Yleistietoa mallijärjestelmästä löydät [täältä](index.md).
+Helmet-käyttöliittymän (UI) kautta pääset määrittämään projektin asetukset ja lähtötiedot.
 
-Mallin käyttämiä lähtötietoja on kuvattu [täällä](HSL_lahtotiedot.md). HSL:n lähtötietoaineistot (mm. maankäytöt ja verkkojen tiedot) saat ladattua zip-pakettina, kun olet täyttänyt aineistojen luovutuksen hakemuslomakkeen. Lähtötiedot voi ladata sisään Emmen skenaarioihin erillisen makron avulla. 
+### Asetukset
 
-Mallin asennus- ja käyttöohjeet löydät [täältä](kaytto-ohje.md), ja tarkempia lähtötietojen käsittelyn ohjeita sekä Helmet-makrojen ohjeet ja latauslinkin [täältä](sijopankki.md). Pääosin suositellaan käytettäväksi vain HSL:n julkaisemia skriptejä ja näiden oletusparametrejä. Poikkeamat näihin on syytä dokumentoida huolella (ks. [dokumentointiohje](HSL-toiden_dokumentointi.md)).
+Mallin ajoa varten tulee määritellä seuraavat asetukset. 
 
-Kutakin projektia varten kannattaa luoda yksi yhteinen Emme-pankki, johon kootaan eri Helmet-skenaariot (esim. eri linjastovaihtoehdot). Emmeen luodaan kutakin Helmet-skenaariota kohden viisi eri Emme-skenaariota (pyöräliikenne, vuorokausiliikenne, aamuhuipputunti, päivätunti ja iltahuipputunti).
+:warning: **Kansiopoluissa ei saa olla ääkkösiä!**
 
-Helmet-järjestelmä tuottaa valmiiksi erilaisia tulosteita malliajojen tuloksista. Emmellä ja muilla sovelluksilla voidaan tuottaa lisäksi erilaisia analyysejä.
+- Suorituskelpoinen Emme Python 
+  - Tämän **on oltava** Emmen mukana tullut ’python.exe’, jotta tietyt edellytykset täyttyvät.
+  - esim. `C:\Program Files\INRO\Emme\Emme 4\Emme-4.5.0\Python37\python.exe`
+- GitHubin [Helmet 4.1 Model System](https://github.com/HSLdevcom/helmet-model-system)-sivuston kansio ’Scripts’
+  - Kansiossa ovat järjestelmän käyttämät Python-ohjelmat.
+  - Version päivitys voidaan tehdä klikkaamalla "Lataa eri versio...". Nämä eivät korvaa skriptien vanhoja versioita, 
+  vaan uusimmat versiot skripteistä talletetaan uuteen kansioon.
+  - Voidaan käyttää myös olemassa olevaa kansiota.
+- Projektin kansiopolku
+  - Tänne talletetaan Helmet-skenaarioiden (malliajojen) määrittelyt (.json)
+  - Tämä **ei** siis viittaa Emmen projektitiedostoon (.emp)
+- Lähtödatan sisältävä kansio
+  - Tässä ovat omissa alakansioissaan pohjakysyntämatriisit ja nykytilanteen syöttötiedot (2018)
+  - Kansion sisällön saa HSL:ltä (ks. [lähtötietotiedostojen ohje](mallin_lahtotietotiedostot.md))
+- Tulosten tallennuspolku
+  - Tänne talletetaan ennusteajojen tulokset
 
-## Mallin lähtötietoaineistojen jakelu
+Näiden asetusten lisäksi on kehittäjille tarkoitettuja asetuksia helmet-model-system -kansion tiedostossa `dev-config.json`.
+Näihin ei ole tavalliselle käyttäjälle yleensä syytä koskea, mutta joissain tapauksissa hyödyllinen asetusmahdollisuus ei ole vielä implementoitu käyttöliittymään.
+Lisää tietoja `dev-config.json`-tiedoston asetuksista löytyy 
+[tästä](https://github.com/HSLdevcom/helmet-model-system/tree/olusanya/Scripts#configuring-the-model-run-with-dev-configjson).
 
-HSL tarjoaa valmiina erilaisia lähtötietoaineistoja. Näistä löydät yleistietoa [täältä](HSL_lahtotiedot.md) ja tarkemmat kuvaukset [täältä](mallin_lahtotietotiedostot.md).
+### Malliajon määrittely
 
-HSL:n ylläpitämiä ennusteskenaarioiden syöttötietoja luovutetaan ainoastaan täyttämällä hakemuslomake aineistojen luovuttamiseksi. Hakemuslomake löytyy Teams-ryhmästä EXT-Helmet, jonne saat käyttöoikeuden HSL:n Liikennejärjestelmäryhmästä (Jens West). Kutakin projektia varten tulee hakea uudet aineistot, jotta aineistojen käyttöä voidaan seurata sekä varmistutaan, että lähtötiedot ovat aina ajan tasalla.
+Jokaista ajettavaa HELMET-skenaariota kohden on tehtävä seuraavat määrittelyt:
 
-## Ohjeet lähtötietojen muokkaamiseen
+1.	Skenaarion tai ajon nimi
+    - *Skenaario* ei tässä viittaa Emme-skenaarioon, vaan tässä annetaan nimi verkkokuvaus- ja maankäyttötietoyhdistelmälle joka menee yhteen malliajoon.
+2.	Emmen project-tiedosto (.emp)
+3.	Emme-skenaarion numero. 
+   Asetuksista riippuen sijoittelutulokset tallennetaan tähän skenaarioon tai erikseen seuraavaan neljään skenarioon (vrk, aht, pt, iht).
+4.	Kansio, jossa ovat syöttötiedot
+    - esim. `C:\Helmet\Scenario_input_data\2030`
+    - Kansiossa on oltava *yksi* kappale kustakin tiedostotyypista .cco, .edu, .ext, .lnd, .pop, .prk, .tco, .trk sekä .wrk. 
+      Tiedostojen nimillä ei ole merkitystä, ja ne voivat poiketa toisistaan (kansiossa voi esim. olla 2023.pop ja 2023_b.wrk).
+5.	Suoritettavien iteraatiokierrosten enimmäismäärä (yleensä 10)
+    - Voit myös tehdä pelkän loppusijoittelun, jolloin iteraatioita ei ajeta. Pelkän
+      loppusijoittelun tekeminen vaatii, että kysyntämatriisit omx-muodossa aiemmasta malliajosta
+      löytyvät skenaarion tuloskansiosta.
+6.	Valinta, lasketaanko joukkoliikenteen kustannusmatriisi vai käytetäänkö aiemmin laskettua 
+   (sijaitsee tämän skenaarion tuloskansiossa `Tulosten tallennuspolku\Skenaario nimi`).
+7.  Valinta, poistetaanko sijoittelun strategiatiedostot malliajon jälkeen.
+8.  Valinta, tallennetaanko eri ajanjaksot erillisiin Emme-skenaarioihin.
+9.  Valinta, tallennetaanko mm. joukkoliikenteen matka-ajan osamatriisit (in-vehicle time, first
+    waiting time, jne.). Malliajoon ja hankearviointiin tarpeelliset matriisit tallennetaan
+    aina .omx-muodossa riippumatta tästä valinnasta.
+    - Mikäli halutaan useiden Helmet-skenaarioiden kaikki Emme-matriisit talteen samaan
+      Emme-projektiin (.emx-tiedostoihin), voidaan lisäksi ennen jokaista malliajoa määrittää
+      ensimmäisen matriisin numero. Varataan yhteen malliajoon aina 300 matriisin numeroavaruus,
+      joten jos ensimmäiseen malliajoon on käytetty 100 (oletus), toiseen malliajoon kannattaa
+      laittaa 400.
 
-Yleensä mallitöiden yhteydessä on tarpeen muokata joitakin lähtötietoja. Lähtötietoja voi muokata joko sisään ajettavia tiedostoja editoimalla (ja ajamalla muokatut tiedot uudelleen sisään) tai Emme-ohjelman kautta. Tehdyt muutokset on hyvä dokumentoida huolella.
+### Hyöty-kustannusanalyysin (hankearvioinnin) määrittely
 
-Yleistietoa HSL:n tarjoamista lähtötietoaineistoista ja tarkempia muokkausohjeita löydät [täältä](HSL_lahtotiedot.md) ja [täältä](mallin_lahtotietotiedostot.md). Noudatathan HSL:n ohjeita ja periaatteita verkonkuvauksia koodatessa, jotta varmistutaan tulosten oikeellisuudesta ja aineistojen yhteiskäyttöisyydestä.
+H/K-analyysillä voidaan verrata ajettujen skenaarioiden hyötyjä ja kustannuksia. Tulokset tulostuvat excel-tiedostoon tuloskansiossa. Analyysia varten on määriteltävä:
 
-## Ohjeet malliajoon muokatuilla lähtötiedoilla
+1. Vertailuvaihtoehdon (ve0) tuloskansio (`Tulosten tallennuspolku\Skenaarion nimi`)
+2. Hankevaihtoehdon (ve1) tuloskansio
 
-Lähtötietojen muokkaamisen jälkeen varmista, että muutokset tulevat mukaan kaikkiin haluamiisi skenaarioihin. Lähtötietojen sisäänajomakrolla (ks. [ohje](sijopankki.md)) voit päivittää lähtötietotiedostoihin muokattuja tietoja useampaan skenaarioon kerrallaan. Vaihtoehtoisesti voi Emmen kautta esim. liikenneverkkoon tehtyjä muutoksia kopioida muihin skenaarioihin .ems-muutostiedostojen avulla.
+Jos ennusteita on ajettu kahdelle vuodelle (esim. 2040 ja 2060), vertailuvaihtoehto ja hankevaihtoehto on mahdollista määrittää toisellekin ennustevuodelle.
 
-Varmista ennen malliajoa myös, että Helmet 4-käyttöliittymä viittaa haluamaasi ennusteskenaarion lähtötietokansioon (maankäyttö, kustannukset ym), ja että tulokset tallentuvat haluttuun paikkaan (ks. [mallin käyttö-ohje](kaytto-ohje.md)).
+## Tulosten käsittely ja tulkinta
 
-Lähtötietojen muokkaamisen jälkeen voit ajaa mallin [Helmet 4-käyttöliittymän ohjeen](kaytto-ohje.md) mukaan.
-
-## Tulostiedot
-
-Tulostiedostoista ja niiden analysoinnista lisätietoja [täällä](tulokset.md).
-
+Lisätietoa mallin tuottamista tulostiedostoista ja tulosten tulkinnasta [täällä](tulokset.md).
 Esimerkkejä mallituloksista tehtävistä visualisoinneista [täällä](esimerkkeja_tuloksista.md).
 
 ## Dokumentointi ja aineistojen luovutus
 
-Työn lopuksi kannattaa dokumentoida huolella tehdyt muutokset. Yleensä työn tilaajalla on tietyt toiveet siitä, millaiset dokumentit mallitöistä halutaan. HSL:n tilaamissa töissä kaikki tehdyt muutokset tulee dokumentoida ja aineistot luovuttaa [tämän ohjeen](HSL-toiden_dokumentointi.md) mukaan.  
+Työn lopuksi kannattaa dokumentoida huolella tehdyt muutokset. 
+Yleensä työn tilaajalla on tietyt toiveet siitä, millaiset dokumentit mallitöistä halutaan. 
+HSL:n tilaamissa töissä kaikki tehdyt muutokset tulee dokumentoida ja aineistot luovuttaa [tämän ohjeen](HSL-toiden_dokumentointi.md) mukaan.  

--- a/docs/mallitoiden_yleisohje.md
+++ b/docs/mallitoiden_yleisohje.md
@@ -2,7 +2,7 @@
 sort: 3
 ---
 
-# Ohje mallitöihin
+# Käyttöohje
 
 On tärkeää, että mallia käytetään ja muokataan yhtenäisillä periaatteilla. 
 Näin saadaan mahdollisimman luotettavia tuloksia, ja mahdollistetaan aineistojen  hyödyntäminen myös muissa projekteissa. 

--- a/docs/sijopankki.md
+++ b/docs/sijopankki.md
@@ -1,5 +1,5 @@
 ---
-sort: 3
+sort: 2
 ---
 
 # Uuden HELMET 4.1 sij19 -sijoittelupankin perustaminen ”tyhjästä”

--- a/docs/sijopankki.md
+++ b/docs/sijopankki.md
@@ -2,7 +2,7 @@
 sort: 2
 ---
 
-# Uuden HELMET 4.1 sij19 -sijoittelupankin perustaminen ”tyhjästä”
+# Sijoittelupankin perustaminen
 
 ## Luo uusi Emme-projekti haluamaasi kansioon
 - File - New - Project…

--- a/docs/tulokset.md
+++ b/docs/tulokset.md
@@ -124,3 +124,36 @@ Tuntimatriisit aggregoidaan mallijärjestelmässä koko vuorokauteen kiinteillä
 | time_xxx.txt   | Matka-aikamatriisit [min] kulkumuodoittain | Henkilöauto- ja joukkoliikennematriisit on jaettu työ- ja vapaa-ajan matkojen matriiseihin. |
 | dist_xxx.txt   | Matkaetäisyysmatriisit [km] kulkumuodoittain | Henkilöauto- ja joukkoliikennematriisit on jaettu työ- ja vapaa-ajan matkojen matriiseihin. |
 | cost_xxx.txt   | Tiemaksu- sekä joukkoliikenteen kuukausilippukustannusmatriisit [eur] kulkumuodoittain | Henkilöauto- ja joukkoliikennematriisit on jaettu työ- ja vapaa-ajan matkojen matriiseihin. |
+
+## Tulokset verrattuna Helmet 3.1:een
+
+Autoliikenteen liikennemäärät ovat pääväylillä hieman pienempiä kuin Helmet 3.1 versiossa ja vastaavasti poikittaisessa liikenteessä kehäteillä on enemmän kuormitusta.
+Uudet liikennemäärät vastaavat hieman paremmin laskentatietoja, mutta molemmissa malliversiossa vastaavuus on hyvällä tasolla.
+
+Joukkoliikennekulkutapojen väliset painosuhteet muuttuvat siten, että uusi malliversio ennustaa enemmän juna- ja raitiotiematkoja,
+mikä on todennäköisesti seurausta joukkoliikenteen ruuhkasijoittelun käyttöönotosta malliversioiden välillä.
+Muutos on juna- ja raitioliikenteessä oikeansuuntainen suhteessa laskentatietoihin.
+
+Muutoksiin reagoimisen osalta malli toimii vähemmän herkästi suhteessa Helmet 3.1 -malliin.
+Erityisenä huomiona muutoksien osalta aiemman malliversion jalankulkumalli reagoi hyvin voimakkaasti pysäköintimaksujen nostoon,
+koska kustannus oli mallissa mukana suorana matkojen määrää ennustavana muuttujana ja kulkutavan valinta ei ollut liitoksissa muiden kulkutapojen
+valintaan ja olosuhteiden kehitykseen.
+
+## Helmet 4 -tuloksiin liittyviä epävarmuuksia
+
+Mallia laadittaessa sen antamia tuloksia on verrattu monipuolisesti erilaiseen havaintoaineistoon ja pyritty saamaan tulokset vastaamaan mahdollisimman hyvin havaintoja.
+Tuloksiin liittyy silti tiettyjä epävarmuuksia ja rajoitteita, joista on nostettu tähän keskeisimpiä havaintoja.
+Mallin testausta ja testien tuloksia on kuvattu laajemmin raportissa
+[Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://hslfi.azureedge.net/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf) (luvut 12 ja 13).
+
+Nykytilanteen osalta malli toimii hyvin, eikä kysynnän ennustamiseen liittyviä systemaattisia virheitä testauksessa havaittu.
+Malli tuottaa suuntautumisen, autoliikennemäärien ja pyöräliikennemäärien osalta ulkopuolisia havaintoja vastaavia nykytilanteen ennusteita.
+Mallin tulokset eivät poikkea nykytilanteen osalta merkittävästi Helmet 3.1-versiosta.
+
+Joukkoliikenteen osalta havaittiin kuitenkin ongelma, joka on syytä huomioida hanketarkasteluissa.
+Vuorokauden matkustajamääräarviot on aliarvioitu runkoyhteyksillä metrolla, junalla ja raitiovaunuilla, kun taas bussien matkustajamäärät on hieman yliarvioitu.
+Huipputuntien osalta nykyennuste vastaa laskentoja hyvin, joten ongelma on todennäköisesti vuorokausilaajennuskertoimissa,
+jotka eivät nykyisellään huomioi runkoyhteyksien ja muiden yhteyksien erilaisia liikennöintiaikoja.
+
+Helmet 4 -mallin avulla tehtäviä H/K-laskelmia kannattanee hyödyntää vain suurille liikennejärjestelmätason hankkeille.
+

--- a/docs/tulokset.md
+++ b/docs/tulokset.md
@@ -1,5 +1,5 @@
 ---
-sort: 4
+sort: 5
 ---
 
 # Malliajon tulokset


### PR DESCRIPTION
- Make the order of the documentation files more logical
- Shorten the titles
- Installation instruction as a separate page
- Make the "general instructions" more concise and merge them with the more specific UI user guide