### PR TITLE
Upgrade dev version to 4.1.5-SNAPSHOT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helmet-ui",
-  "version": "4.1.4",
+  "version": "4.1.5-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "helmet-ui",
-      "version": "4.1.4",
+      "version": "4.1.5-SNAPSHOT",
       "license": "EUPL-1.2",
       "dependencies": {
         "@electron/remote": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helmet-ui",
   "productName": "Helmet 4.1",
-  "version": "4.1.4",
+  "version": "4.1.5-SNAPSHOT",
   "private": true,
   "description": "Helmet 4 Model System UI",
   "main": "src/main/index.js",


### PR DESCRIPTION
This is for development purposes: easier to notice that we are looking at the dev version when `npm start` shows v4.1.5-SNAPSHOT instead of the current latest release v4.1.4:
![kuva](https://github.com/HSLdevcom/helmet-ui/assets/20718745/65382e6e-1dd9-49f5-8a5f-77e7a0ee55f0)

Before an actual release, please remove "SNAPSHOT" as instructed in README: https://github.com/HSLdevcom/helmet-ui/tree/v4.1.4#publishing-releases