### PR TITLE
Let's solve this eternal problem by muting the python worker

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -157,7 +157,7 @@ ipcMain.on('loggable-event-from-worker', (event, args) => {
     // utils.log
     event_args = JSON.parse(event_string);
   } catch (error) {
-    // numpy warnings
+    // numpy warnings and other non-log messages
     event_args = {
       "level": "EXCEPTION",
       "message": event_string,
@@ -167,10 +167,10 @@ ipcMain.on('loggable-event-from-worker', (event, args) => {
   mainWindow.webContents.send('loggable-event', event_args);
 });
 
-// Log worker-errors (by PythonShell, not stderr) in main console
-ipcMain.on('process-error-from-worker', (event, args) => {
-  mainWindow.webContents.send('loggable-event', {
-    "level": "ERROR",
-    "message": (typeof args === "string") ? args : JSON.stringify(args)
-  });
-});
+// // Log worker-errors (by PythonShell, not stderr) in main console
+// ipcMain.on('process-error-from-worker', (event, args) => {
+//   mainWindow.webContents.send('loggable-event', {
+//     "level": "ERROR",
+//     "message": (typeof args === "string") ? args : JSON.stringify(args)
+//   });
+// });


### PR DESCRIPTION
We have three sources for the error messages:

1) [ERROR] message coming from log.error (predicted error)
2) [EXCEPTION] message coming from python shell itself
3) [ERROR] coming from the Python worker

![kuva](https://github.com/HSLdevcom/helmet-ui/assets/127391244/82e9cbed-15f4-4c3f-bca9-d0c8b6c49044)

All of these are very similar, but in case of unpredicted fail we only see 2) and 3). I tried quite hard to come up with the way to unify 1) and 2), it might be possible to mute 2) if 1) was printed previously, but I do not want to rely on it. Let's keep 1) and 2) in the output from now on.
On the other hand, I do not see much reason to keep 3) so I commented it out in this branch. I can also remove it completely, but I want to hear your comments first.