### PR TITLE
#208: Fix prompt focus

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -167,10 +167,8 @@ ipcMain.on('loggable-event-from-worker', (event, args) => {
   mainWindow.webContents.send('loggable-event', event_args);
 });
 
-// // Log worker-errors (by PythonShell, not stderr) in main console
-// ipcMain.on('process-error-from-worker', (event, args) => {
-//   mainWindow.webContents.send('loggable-event', {
-//     "level": "ERROR",
-//     "message": (typeof args === "string") ? args : JSON.stringify(args)
-//   });
-// });
+// This is to fix the inputs not having focus after showing a prompt or alert
+ipcMain.on('focus-fix', () => {
+  mainWindow?.blur();
+  mainWindow?.focus();
+});

--- a/src/renderer/components/HelmetProject/HelmetProject.jsx
+++ b/src/renderer/components/HelmetProject/HelmetProject.jsx
@@ -54,6 +54,7 @@ const HelmetProject = ({
   };
 
   const _handleClickNewScenario = () => {
+    ipcRenderer.send('focus-fix');
     const promptCreation = (previousError) => {
       vex.dialog.prompt({
         message: (previousError ? previousError : "") + "Anna uuden skenaarion nimike:",
@@ -213,7 +214,9 @@ const HelmetProject = ({
       setOpenScenarioID(null);
       setScenarios(scenarios.filter((s) => s.id !== scenario.id));
       fs.unlinkSync(path.join(projectPath, `${scenario.name}.json`));
-      window.location.reload();  // Vex-js dialog input gets stuck otherwise
+      ipcRenderer.send('focus-fix');
+    } else {
+       ipcRenderer.send('focus-fix');
     }
   };
 


### PR DESCRIPTION
The bug mentioned in this issue is first [reported on 2019](https://github.com/electron/electron/issues/19977) to the electron dev team, and due to the native prompts being not asynchronous there are no foreseeable plans to fix this. 

The fix in this PR is a workaround provided by the community in the issue report, and seems to do the trick atleast on Windows 10. This issue is not present at all on Mac/OSX, even before the fix.

