### PR TITLE
#216: UI Improvements

### DIFF
--- a/src/renderer/components/App.css
+++ b/src/renderer/components/App.css
@@ -89,6 +89,14 @@ hr {
     cursor: pointer;
 }
 
+.App__settings-disabled {
+    -webkit-filter: grayscale(100%);
+    filter: grayscale(1);
+    background-color:#d0d0d0;
+    background-blend-mode: darken;
+    cursor: default;
+}
+
 .App__header {
     display: flex;
     align-items: center;

--- a/src/renderer/components/App.jsx
+++ b/src/renderer/components/App.jsx
@@ -6,6 +6,7 @@ const homedir = require('os').homedir();
 const {ipcRenderer, shell, ipcMain} = require('electron');
 const {execSync} = require('child_process');
 const path = require('path');
+const classNames = require('classnames');
 
 // vex-js imported globally in index.html, since we cannot access webpack config in electron-forge
 const App = ({helmetUIVersion, versions, searchEMMEPython}) => {
@@ -264,12 +265,12 @@ const App = ({helmetUIVersion, versions, searchEMMEPython}) => {
         <a className="header-documentation-link" title='Dokumentaatio' 
           target="_blank" 
           onClick={() => shell.openExternal("https://hsldevcom.github.io/helmet-docs/")}
-          style={{display: isSettingsOpen | isProjectRunning ? "none" : "flex"}}> 
+          style={{display: isSettingsOpen ? "none" : "flex"}}> 
             <span>?</span>
         </a>
-        <div className="App__open-settings" title='Asetukset'
-          style={{display: isSettingsOpen | isProjectRunning ? "none" : "block"}}
-          onClick={() => setSettingsOpen(true)}>
+        <div className={classNames("App__open-settings", { 'App__settings-disabled': isProjectRunning })} title='Asetukset'
+          style={{display: isSettingsOpen ? "none" : "block"}}
+          onClick={() => isProjectRunning ? setSettingsOpen(false) : setSettingsOpen(true)}>
         </div>
       </div>
     </div>

--- a/src/renderer/components/HelmetProject/Runtime/Runtime.jsx
+++ b/src/renderer/components/HelmetProject/Runtime/Runtime.jsx
@@ -122,9 +122,11 @@ const Runtime = ({
   }
 
   useEffect(() => {
+    const resizableDiv = document.getElementById("resizableDiv");
     if (scenarioListHeight) {
-      const resizableDiv = document.getElementById("resizableDiv");
       resizableDiv.style.height = scenarioListHeight;
+    } else {
+      resizableDiv.style.height = '300px';
     }
   });
 

--- a/src/renderer/components/Settings/Settings.css
+++ b/src/renderer/components/Settings/Settings.css
@@ -46,9 +46,6 @@
     margin-bottom: 1rem;
 }
 
-.Settings__dialog-input-group {
-}
-
 .Settings__pseudo-label {
     display: block;
     font-style: normal;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -42,6 +42,9 @@
     <script type="text/babel" src="./icons/ArrowUp.jsx"></script>
     <script type="text/babel" src="./icons/ArrowRight.jsx"></script>
     <script src="node_modules/electron-tabs/dist/electron-tabs.js"></script>
+    <style>
+      html, body { width: 100%; height: 100%; }
+    </style>
 </head>
 <body>
 


### PR DESCRIPTION
- Gray out the "Settings" button instead of hiding it during running scenarios
- Make documentation button visible during scenario running
- App no longer has the white strip under the gray overlay when opening settings modal
- Scenarios list starts out as a fixed height, no matter the amount of scenarios in the list